### PR TITLE
Bring roles into line with roles used in solr repository

### DIFF
--- a/provision-telegraf.yml
+++ b/provision-telegraf.yml
@@ -30,7 +30,8 @@
     - set_fact:
         num_kafka_nodes: "{{groups['kafka'] | default([]) | length}}"
     # if we didn't find any nodes in the kafka host group, then it's an error
-    - fail:
+    - name: Fail playbook run if an (external) Kafka instance/cluster not found
+      fail:
         msg: "An (external) Kafka cluster is required for telegraf deployments"
       when: num_kafka_nodes | int == 0
 

--- a/roles/build-app-host-groups/files/build_aws_host_groups.yml
+++ b/roles/build-app-host-groups/files/build_aws_host_groups.yml
@@ -9,9 +9,9 @@
     node_list_name: "{{(hg_item_role == 'none') | ternary((hg_item_name + '_nodes'), (hg_item_name + '_' + hg_item_role + '_nodes'))}}"
     app_group_name: "{{(hg_item_role == 'none') | ternary(hg_item_name,(hg_item_name + '_' + hg_item_role))}}"
 # then, gather the facts that are used to create our host group from the
-# `ec2_remote_facts` module
+# `ec2_instance_facts` module
 - name: Gather facts for the hosts that match our filter
-  ec2_remote_facts:
+  ec2_instance_facts:
     region: "{{region}}"
     filters:
       instance-state-name: running

--- a/roles/build-app-host-groups/files/build_osp_host_groups.yml
+++ b/roles/build-app-host-groups/files/build_osp_host_groups.yml
@@ -29,17 +29,24 @@
 # containing that list and create the appropriately named host groups
 - set_fact:
     "{{node_list_name}}": "{{app_nodes}}"
+
 - name: Create {{app_group_name}} host group from OpenStack meta-data
   add_host:
     name: "{{item}}"
     groups: "{{app_group_name}},{{node_list_name}}"
-    ansible_ssh_host: "{{(os_inventory_json | json_query('_meta.hostvars.\"' + item + '\".openstack.addresses.private[].addr') | list).0}}"
+    ansible_host: "{{ (os_inventory_json | json_query('_meta.hostvars.\"' + item + '\".openstack.addresses.private[1].addr')) }}"
     ansible_ssh_private_key_file: "{{private_key_path}}/{{region}}-{{project}}-{{hg_item_name}}-{{domain}}-private-key.pem"
   with_items: "{{app_nodes | default([])}}"
-# finally, add the floating IP addresses for nodes in this application group to
-# the `osp_floating_ip` list (this fact currently is not used, but it was used
-# in the past so we still build it)
-- name: Add floating IP addresses to osp_floating_ip for the {{app_group_name}} nodes
-  set_fact:
-    osp_floating_ip: "{{(osp_floating_ip | default({})) | combine({item: (os_inventory_json | json_query('_meta.hostvars.\"' + item + '\".openstack.addresses.public') | selectattr('OS-EXT-IPS:type', 'equalto', 'floating') | map(attribute='addr') | list).0})}}"
+  when:
+    - internal_uuid == external_uuid
+
+# multiple subnet hostgroups already have the correct ansible_host
+- name: Create {{app_group_name}} host group from OpenStack meta-data
+  add_host:
+    name: "{{item}}"
+    groups: "{{app_group_name}},{{node_list_name}}"
+    ansible_host: "{{(os_inventory_json | json_query('_meta.hostvars.\"' + item + '\".openstack.addresses.private[].addr') | list).0}}"
+    ansible_ssh_private_key_file: "{{private_key_path}}/{{region}}-{{project}}-{{hg_item_name}}-{{domain}}-private-key.pem"
   with_items: "{{app_nodes | default([])}}"
+  when:
+    - internal_uuid != external_uuid

--- a/roles/build-app-host-groups/tasks/main.yml
+++ b/roles/build-app-host-groups/tasks/main.yml
@@ -22,14 +22,14 @@
       cluster_nodes: "{{(os_inventory_json | json_query('[\"meta-Cluster_' + (cluster | default('a')) + '\"]')).0}}"
   # and, finally, loop through the host_group_list, building each host group
   # (in turn) from the lists of nodes we just constructed
-  - include: ../files/build_osp_host_groups.yml
+  - include_tasks: ../files/build_osp_host_groups.yml
     with_items: "{{host_group_list}}"
     loop_control:
       loop_var: host_group_item
   when: cloud == "osp"
 # If we're building a cluster in an AWS environtment, then loop through the
 # host_group_list, building each host group (in turn)
-- include: ../files/build_aws_host_groups.yml
+- include_tasks: ../files/build_aws_host_groups.yml
   with_items: "{{host_group_list}}"
   loop_control:
     loop_var: host_group_item

--- a/roles/build-app-host-groups/utils/openstack.py
+++ b/roles/build-app-host-groups/utils/openstack.py
@@ -120,7 +120,7 @@ def get_host_groups(inventory, refresh=False):
 
 def append_hostvars(hostvars, groups, key, server, namegroup=False):
     hostvars[key] = dict(
-        ansible_ssh_host=server['interface_ip'],
+        ansible_host=server['interface_ip'],
         openstack=server)
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)

--- a/roles/configure-telegraf-nodes/tasks/configure-input.yml
+++ b/roles/configure-telegraf-nodes/tasks/configure-input.yml
@@ -11,6 +11,5 @@
 - local_action: stat path="{{config_filename}}"
   register: check_path
 # if so, then include that file (to customize that `input_filter_entry`)
-- include: "{{config_filename}}"
-  static: no
+- include_tasks: "{{config_filename}}"
   when: check_path.stat.exists

--- a/roles/configure-telegraf-nodes/tasks/configure-inputs.yml
+++ b/roles/configure-telegraf-nodes/tasks/configure-inputs.yml
@@ -7,7 +7,7 @@
 # (if such configuration parameters exist)
 - set_fact:
     input_filter_elements: "{{(measurement_set.input_filter | default('')).split(':')}}"
-- include: configure-input.yml static=no
+- include_tasks: configure-input.yml
   with_items: "{{input_filter_elements}}"
   loop_control:
     loop_var: input_filter_entry

--- a/roles/configure-telegraf-nodes/tasks/configure-output.yml
+++ b/roles/configure-telegraf-nodes/tasks/configure-output.yml
@@ -11,6 +11,5 @@
 - local_action: stat path="{{config_filename}}"
   register: check_path
 # if so, then include that file (to customize that `output_filter_entry`)
-- include: "{{config_filename}}"
-  static: no
+- include_tasks: "{{config_filename}}"
   when: check_path.stat.exists

--- a/roles/configure-telegraf-nodes/tasks/configure-outputs.yml
+++ b/roles/configure-telegraf-nodes/tasks/configure-outputs.yml
@@ -7,7 +7,7 @@
 # (if such configuration parameters exist)
 - set_fact:
     output_filter_elements: "{{(measurement_set.output_filter | default('')).split(':')}}"
-- include: configure-output.yml static=no
+- include_tasks: configure-output.yml
   with_items: "{{output_filter_elements}}"
   loop_control:
     loop_var: output_filter_entry

--- a/roles/configure-telegraf-nodes/tasks/generate-new-telegraf-configs.yml
+++ b/roles/configure-telegraf-nodes/tasks/generate-new-telegraf-configs.yml
@@ -15,13 +15,13 @@
 # list, customize the configuration file for that `measurement_set` based on
 # the `config` parameters defined for the inputs declared for that
 # `measurement_set`
-- include: configure-inputs.yml static=no
+- include_tasks: configure-inputs.yml
   with_items: "{{measurement_set_configs}}"
   loop_control:
     loop_var: measurement_set
 # and repeat that process for the outputs declared in each of the
 # `measurement_sets` in the `measurement_set_configs` list
-- include: configure-outputs.yml static=no
+- include_tasks: configure-outputs.yml
   with_items: "{{measurement_set_configs}}"
   loop_control:
     loop_var: measurement_set

--- a/roles/initialize-play/tasks/main.yml
+++ b/roles/initialize-play/tasks/main.yml
@@ -50,16 +50,14 @@
 # description values, while the value that type is set to will depend on the
 # 'type' in each of those values; currently either 'cidr' or 'name' values
 # are supported for the 'type' field)
-- include: "{{role_path}}/files/get_iface_name.yml"
-  static: no
+- include_tasks: "{{role_path}}/files/get_iface_name.yml"
   with_items: "{{iface_description_array}}"
   loop_control:
     loop_var: iface_description
   when: not (iface_description_array is undefined)
 # finally, get values for the addresses of the `data_iface` and `api_iface`
 # (if defined)
-- include: "{{role_path}}/files/get_iface_addr.yml"
-  static: no
+- include_tasks: "{{role_path}}/files/get_iface_addr.yml"
   vars:
     iface_name: "{{data_iface}}"
     as_fact: "data_addr"
@@ -70,8 +68,7 @@
 - set_fact:
     api_iface: "{{(lcl_iface_names | reject('equalto', 'lo') | reject('equalto', data_iface) | list).0}}"
   when: api_iface == ''
-- include: "{{role_path}}/files/get_iface_addr.yml"
-  static: no
+- include_tasks: "{{role_path}}/files/get_iface_addr.yml"
   vars:
     iface_name: "{{api_iface}}"
     as_fact: "api_addr"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 ---
-- include: add-telegraf-repo.yml static=no
-- include: install-telegraf.yml static=no
+- include_tasks: add-telegraf-repo.yml
+- include_tasks: install-telegraf.yml
 - include_role:
     name: configure-telegraf-nodes
     tasks_from: generate-new-telegraf-configs
-- include: create-telegraf-service.yml static=no
-- include: start-telegraf-service.yml static=no
-- include: enable-telegraf-service.yml static=no
+- include_tasks: create-telegraf-service.yml
+- include_tasks: start-telegraf-service.yml
+- include_tasks: enable-telegraf-service.yml

--- a/tasks/start-telegraf-services.yml
+++ b/tasks/start-telegraf-services.yml
@@ -1,7 +1,7 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 ---
 - name: Start telegraf agents
-  include: start-telegraf-service.yml static=no
+  include_tasks: start-telegraf-service.yml
   with_items:
     - metrics
     - logs


### PR DESCRIPTION
The changes in this pull request bring the roles that are included in the `telegraf` repository into line with the latest changes that were made to these roles in the `solr` repository. In addition, this pull request makes the following changes:

* It adds labels to the to the fail tasks in the `provision-telegraf.yml` playbook in order to clarify the output of playbook run (some users were confused by the `fail ... skipped` output generated by previous versions of this file)
* It modifies the playbook to use the new `include_tasks` module to include tasks files during the playbook run (instead of the `include: ... static=no` syntax that was used in previous versions of this playbook); this new module is only available in Ansible v2.4 and later
* It modifies the playbook to use the new `ec2_instance_facts` module to gather facts about instances in an AWS environment (instead of the old `ec2_remote_facts` module that was used in previous versions of this playbook); again this new module is only available in Ansible v2.4 and later, but using it will remove the dependency on the `boto3` Python module that was introduced to the `ec2_remote_facts` module in Ansible v2.4 (previously this module only depended on the `boto` Python module, now both the `boto` and `boto3` modules must be installed to use the `ec2_remote_facts` module...only the `boto` module is required to use the `ec2_instance_facts` module)

With these changes, the `telegraf` repository should now be in line with recent changes that have been made to our other application repositories (`kafka`, `solr`, etc.)