### PR TITLE
Resolves #4 (Generates "blank" configuration file from template)

### DIFF
--- a/roles/configure-telegraf-nodes/tasks/configure-agent.yml
+++ b/roles/configure-telegraf-nodes/tasks/configure-agent.yml
@@ -4,48 +4,18 @@
 # agent_config
 - set_fact:
     precision: '{{(agent_config.config | default({})).precision | default("1ns")}}'
-# Then customize the Kafka output section of the configuration file associated
-# with the input `measurement_set` file to include those parameters; it should
-# be noted here that the current version of the playbook only supports outputting
-# data in a JSON data format; to support other formats additional changes to this
-# task file will be necessary)
+# Then create a new `/etc/telegraf/telegraf.conf` file containing only the
+# agent configuration (the configuration for each of the "measurement sets"
+# will be handled separately in configuration files created and placed into
+# the `/etc/telegraf/telegraf.d` subdirectory)
 - block:
-  - name: Delete the default telegraf agent configuration
+  - name: Ensure the default telegraf agent configuration file is removed
     file:
       path: "/etc/telegraf/telegraf.conf"
       state: absent
-  - name: Create a new (empty) configuration file
-    shell: telegraf --input-filter '' --output-filter '' config > /etc/telegraf/telegraf.conf
-  - name: Configure the default configuration to match the agent configuration
-    replace:
-      dest: "/etc/telegraf/telegraf.conf"
-      regexp: "{{ item.regexp }}"
-      replace: "{{ item.replace }}"
-    with_items:
-      - { regexp: '^(#)?(.*)precision = (.*)$' , replace: '\g<2>precision = "{{precision}}"' }
-  - name: Ensure the default (influxdb) output and default inputs are disabled
-    replace:
-      dest: "/etc/telegraf/telegraf.conf"
-      regexp: "{{ item.regexp }}"
-      replace: "{{ item.replace }}"
-    with_items:
-    - { regexp: '^(\[\[outputs\.influxdb\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^([ ]*)(urls =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^([ ]*)(database =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^([ ]*)(retention_policy =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^([ ]*)(write_consistency =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^([ ]*)(timeout =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^(\[\[inputs\.cpu\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^([ ]*)(percpu =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^([ ]*)(totalcpu =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^([ ]*)(collect_cpu_time =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^([ ]*)(report_active =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^(\[\[inputs\.disk\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^([ ]*)(ignore_fs =.*)$' , replace: '#\g<1>\g<2>' }
-    - { regexp: '^(\[\[inputs\.diskio\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^(\[\[inputs\.kernel\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^(\[\[inputs\.mem\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^(\[\[inputs\.processes\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^(\[\[inputs\.swap\]\])$' , replace: '#\g<1>' }
-    - { regexp: '^(\[\[inputs\.system\]\])$' , replace: '#\g<1>' }
+  - name: Create a new (empty) configuration file from the template
+    template:
+      src: telegraf.conf.j2
+      dest: /etc/telegraf/telegraf.conf
+      mode: 0644
   become: true

--- a/roles/configure-telegraf-nodes/templates/telegraf.conf.j2
+++ b/roles/configure-telegraf-nodes/templates/telegraf.conf.j2
@@ -1,0 +1,78 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply prepend
+# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
+# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
+
+
+# Global tags can be specified here in key="value" format.
+[global_tags]
+  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
+  # rack = "1a"
+  ## Environment variables can be used as tags, and throughout the config file
+  # user = "$USER"
+
+
+# Configuration for telegraf agent
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "10s"
+  ## Rounds collection interval to 'interval'
+  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  ## Telegraf will send metrics to outputs in batches of at most
+  ## metric_batch_size metrics.
+  ## This controls the size of writes that Telegraf sends to output plugins.
+  metric_batch_size = 1000
+
+  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+  ## output, and will flush this buffer on a successful write. Oldest metrics
+  ## are dropped first when this buffer fills.
+  ## This buffer only fills when writes fail to output plugin(s).
+  metric_buffer_limit = 10000
+
+  ## Collection jitter is used to jitter the collection by a random amount.
+  ## Each plugin will sleep for a random time within jitter before collecting.
+  ## This can be used to avoid many plugins querying things like sysfs at the
+  ## same time, which can have a measurable effect on the system.
+  collection_jitter = "0s"
+
+  ## Default flushing interval for all outputs. You shouldn't set this below
+  ## interval. Maximum flush_interval will be flush_interval + flush_jitter
+  flush_interval = "10s"
+  ## Jitter the flush interval by a random amount. This is primarily to avoid
+  ## large write spikes for users running a large number of telegraf instances.
+  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "0s"
+
+  ## By default or when set to "0s", precision will be set to the same
+  ## timestamp order as the collection interval, with the maximum being 1s.
+  ##   ie, when interval = "10s", precision will be "1s"
+  ##       when interval = "250ms", precision will be "1ms"
+  ## Precision will NOT be used for service inputs. It is up to each individual
+  ## service input to set the timestamp at the appropriate precision.
+  ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
+  precision = "{{precision}}"
+
+  ## Logging configuration:
+  ## Run telegraf with debug log messages.
+  debug = false
+  ## Run telegraf in quiet mode (error log messages only).
+  quiet = false
+  ## Specify the log file name. The empty string means to log to stderr.
+  logfile = ""
+
+  ## Override default hostname, if empty use os.Hostname()
+  hostname = ""
+  ## If set to true, do no set the "host" tag in the telegraf agent.
+  omit_hostname = false


### PR DESCRIPTION
The changes in this pull request add a template to the repository and use that template to generate the "blank" configuration file used when starting the Telegraf agent.

Previously, this "blank" template was generated by running a `telegraf ... config` command locally on each machine where no inputs or outputs were defined (by not passing in the `-input-filter` and `--output-filter` flags or by defining an empty string for the value of passed in using these two flags). In a recent release of the Telegraf project, the behavior of this command was changed to create a default set of inputs and outputs if these two flags were not included on the `telegraf ... config` command or if a blank string was passed as the value for these two flags. We submitted a PR against this project recently to update the playbook to comment out these new (default) inputs and outputs in the resulting `telegraf.conf` file, but the approach we took in that pull request (PR #3) is somewhat brittle since it used an array of regular expressions that were fed into a call to the Ansible `replace` module (to replace the matching lines with commented out versions of those same lines).

This pull request modifies the `configure-agent.yml` task file in the `configure-telegraf-nodes` role to use a template to define the main `/etc/telegraf/telegraf.conf` file (ensuring that this file only includes the agent configuration parameters that we used to generate with a "blank" `telegraf ... config` command). The remaining task files in this role remain the same, and we have tested this change locally using a Kafka VM and a static configuration file (so we know that even with the latest version of the Telegraf repository this playbook works as expected, deploying, configuring, and starting up a Telegraf agent on the target nodes with the agent configuration defined in the `/etc/telegraf/telegraf.conf` file and the configurations for the defined measurement sets defined in their own configuration files in the `/etc/telegraf/telegraf.d` directory).